### PR TITLE
Added prelim microdata/rich snippets for Products

### DIFF
--- a/site/snippets/product.gallery.php
+++ b/site/snippets/product.gallery.php
@@ -1,20 +1,23 @@
 <?php if ($page->hasImages()) { ?>
 	<section class="gallery">
-		
+
 		<?php $first = true ?>
-		<?php foreach ($page->images() as $photo) { ?>	
+		<?php foreach ($page->images() as $photo) { ?>
+			<span itemprop="image" itemscope itemtype="http://schema.org/ImageObject">
 			<!-- Radio button (hidden with CSS) -->
 			<input <?php ecco($first,'checked') ?> type="radio" name="thumbnail" id="<?php echo $photo->hash() ?>">
 			<?php $first = false ?>
-			
+
 			<!-- Large photo -->
-			<img src="<?php echo thumb($photo,array('height'=>300))->dataUri() ?>" title="<?php echo $photo->title() ?>"/>
+				<img itemprop="contentUrl" src="<?php echo thumb($photo,array('height'=>300))->dataUri() ?>" title="<?php echo $photo->title() ?>"/>
+				<meta itemprop="name" content="<?php echo $photo->title() ?>">
+			</span>
 		<?php } ?>
 
 		<!-- Show thumbnails if there are multiple photos -->
 		<?php if ($page->images()->count() > 1) { ?>
 			<ul class="uk-grid uk-grid-width-1-4">
-				<?php foreach ($page->images() as $photo) { ?>	
+				<?php foreach ($page->images() as $photo) { ?>
 					<li>
 						<label for="<?php echo $photo->hash() ?>">
 							<img src="<?php echo thumb($photo,array('width'=>100,'height'=>100, 'quality'=>80, 'crop'=>true))->dataUri() ?>" title="<?php echo $photo->title() ?>"/>

--- a/site/templates/product.php
+++ b/site/templates/product.php
@@ -1,65 +1,74 @@
 <?php snippet('header') ?>
 
 		<?php snippet('breadcrumb') ?>
-		
-		<h1><?php echo $page->title()->html() ?></h1>
+
+		<div itemscope itemtype="http://schema.org/Product">
+
+			<h1 itemprop="name"><?php echo $page->title()->html() ?></h1>
+
+			<div class="uk-grid uk-grid-width-medium-1-2">
+
+				<div>
+					<section itemprop="description">
+						<?php echo $page->text()->kirbytext() ?>
+
+						<?php $tags = str::split($page->tags()) ?>
+						<?php if (count($tags)) { ?>
+							<p>
+								<?php foreach ($tags as $tag) { ?>
+									<a itemprop="category" href="<?php echo $site->url().'/search/?q='.urlencode($tag) ?>">#<?php echo $tag ?></a>
+								<?php } ?>
+							</p>
+						<?php } ?>
+					</section>
+
+					<?php snippet('product.gallery') ?>
+				</div>
 
 
+				<?php $variants = $page->variants()->toStructure() ?>
+				<?php if (count($variants)) { ?>
+					<section class="variants uk-grid uk-grid-width-1-2 uk-grid-collapse">
+						<?php foreach ($variants as $variant) { ?>
+							<div itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+					            <form class="uk-form uk-panel uk-panel-box" method="post" action="<?php echo url('shop/cart') ?>">
 
-		<div class="uk-grid uk-grid-width-medium-1-2">
-			
-			<div>
-				<section>
-					<?php echo $page->text()->kirbytext() ?>
+									<h3 itemprop="itemOffered" class="uk-margin-small-bottom"><?php echo $variant->name() ?></h3>
 
-					<?php $tags = str::split($page->tags()) ?>
-					<?php if (count($tags)) { ?>
-						<p>
-							<?php foreach ($tags as $tag) { ?>
-								<a href="<?php echo $site->url().'/search/?q='.urlencode($tag) ?>">#<?php echo $tag ?></a>
-							<?php } ?>
-						</p>
-					<?php } ?>
-				</section>
+									<?php ecco(trim($variant->description()) != '',$variant->description()->kirbytext()) ?>
 
-				<?php snippet('product.gallery') ?>
+					                <input type="hidden" name="action" value="add">
+					                <input type="hidden" name="uri" value="<?php echo $page->uri() ?>">
+					                <input type="hidden" name="variant" value="<?php echo str::slug($variant->name()) ?>">
+
+									<?php $options = str::split($variant->options()) ?>
+									<?php if (count($options)) { ?>
+										<select class="uk-width-1-1" name="option">
+											<?php foreach ($options as $option) { ?>
+												<option value="<?php echo str::slug($option) ?>"><?php echo str::ucfirst($option) ?></option>
+											<?php } ?>
+										</select>
+									<?php } ?>
+
+									<?php if (inStock($variant)) { ?>
+										<link itemprop="availability" href="http://schema.org/InStock" />
+										<button class="uk-button uk-button-primary uk-width-1-1" type="submit">
+											<?php echo l::get('buy') ?>
+											<span itemprop="price"><?php echo formatPrice($variant->price()->value) ?></span>
+										</button>
+									<?php } else { ?>
+										<link itemprop="availability" href="https://schema.org/OutOfStock" />
+										<button class="uk-button uk-button-primary uk-width-1-1" disabled>
+											<?php echo l::get('out-of-stock') ?>
+											<span itemprop="price"><?php echo formatPrice($variant->price()->value) ?></span>
+										</button>
+									<?php } ?>
+					            </form>
+							</div>
+						<?php } ?>
+					</section>
+				<?php } ?>
 			</div>
-			
-			
-			<?php $variants = $page->variants()->toStructure() ?>
-			<?php if (count($variants)) { ?>
-				<section class="variants uk-grid uk-grid-width-1-2 uk-grid-collapse">
-					<?php foreach ($variants as $variant) { ?>
-						<div>
-				            <form class="uk-form uk-panel uk-panel-box" method="post" action="<?php echo url('shop/cart') ?>">
-
-								<h3 class="uk-margin-small-bottom"><?php echo $variant->name() ?></h3>
-
-								<?php ecco(trim($variant->description()) != '',$variant->description()->kirbytext()) ?>
-
-				                <input type="hidden" name="action" value="add">
-				                <input type="hidden" name="uri" value="<?php echo $page->uri() ?>">
-				                <input type="hidden" name="variant" value="<?php echo str::slug($variant->name()) ?>">
-
-								<?php $options = str::split($variant->options()) ?>
-								<?php if (count($options)) { ?>
-									<select class="uk-width-1-1" name="option">
-										<?php foreach ($options as $option) { ?>
-											<option value="<?php echo str::slug($option) ?>"><?php echo str::ucfirst($option) ?></option>
-										<?php } ?>
-									</select>
-								<?php } ?>
-
-								<?php if (inStock($variant)) { ?>
-									<button class="uk-button uk-button-primary uk-width-1-1" type="submit"><?php echo l::get('buy') ?> <?php echo formatPrice($variant->price()->value) ?></button>
-								<?php } else { ?>
-									<button class="uk-button uk-button-primary uk-width-1-1" disabled><?php echo l::get('out-of-stock') ?> <?php echo formatPrice($variant->price()->value) ?></button>
-								<?php } ?>
-				            </form>
-						</div>
-					<?php } ?>
-				</section>
-			<?php } ?>
 		</div>
 
 		<!-- Related products -->


### PR DESCRIPTION
Started working on some microdata stuff for fun, but didn't want to go too far since I had to add a couple of `div`s and `span`s to markup the data correctly.

Some interesting schema.org tags for products such as `brand` and `model` aren't usable yet since they're not part of any blueprints. I didn't change the blueprints since I think I would be overstepping my boundaries. :stuck_out_tongue: 

Tell me what you think. #13 
